### PR TITLE
allow skit run without specified path

### DIFF
--- a/bin/skit
+++ b/bin/skit
@@ -110,10 +110,7 @@ function validate_root(root, opt_publicRootName) {
 function command_run(args, positionalArgs) {
   var usage_run = usage.bind(this, 'run');
 
-  if (positionalArgs.length != 1) {
-    usage_run();
-  }
-  var root = positionalArgs[0];
+  var root = positionalArgs[0] || path.resolve(path.dirname());
 
   var errorMessage = validate_root(root, args['public-root']);
   if (errorMessage) {
@@ -136,7 +133,7 @@ function command_run(args, positionalArgs) {
   if (aliasMap) {
     options.aliasMap = aliasMap;
   }
-  
+
   var server = new skit.SkitServer(root, options);
   var port = args['port'];
   server.listen(port);


### PR DESCRIPTION
It was a little frustrating that I had to specify the path when doing `skit run /path...`. This allows someone to just type `skit run` and it picks up on the directory path.
